### PR TITLE
Fixed description rendering on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     description="UPnP for asyncio",
     keywords="upnp asyncio",
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url="https://github.com/lbryio/aioupnp",
     license=__license__,
     packages=find_packages(),


### PR DESCRIPTION
To fix this we need a new `long_description_content_type` field and use latest versions of packages while uploading to PyPI: https://stackoverflow.com/a/26737258.

![image](https://user-images.githubusercontent.com/25141164/47255426-b6ee4500-d479-11e8-890f-678a831bfac0.png)
