### PR TITLE
Fix unclean exit due to uncaught errors/exceptions

### DIFF
--- a/aioupnp/gateway.py
+++ b/aioupnp/gateway.py
@@ -196,6 +196,7 @@ class Gateway:
     async def discover_gateway(cls, lan_address: str, gateway_address: str, timeout: int = 30,
                                igd_args: OrderedDict = None, loop=None, unicast: bool = None):
         if unicast is not None:
+            return await cls._discover_gateway(lan_address, gateway_address, timeout, igd_args, loop, unicast)
             return await cls._discover_gateway(lan_address, gateway_address, timeout, igd_args, loop)
         done, pending = await asyncio.wait([
             cls._discover_gateway(

--- a/aioupnp/gateway.py
+++ b/aioupnp/gateway.py
@@ -197,19 +197,26 @@ class Gateway:
                                igd_args: OrderedDict = None, loop=None, unicast: bool = None):
         if unicast is not None:
             return await cls._discover_gateway(lan_address, gateway_address, timeout, igd_args, loop, unicast)
-            return await cls._discover_gateway(lan_address, gateway_address, timeout, igd_args, loop)
-        done, pending = await asyncio.wait([
-            cls._discover_gateway(
-                lan_address, gateway_address, timeout, igd_args, loop, unicast=True
-            ),
-            cls._discover_gateway(
-                lan_address, gateway_address, timeout, igd_args, loop, unicast=False
-            )], return_when=asyncio.tasks.FIRST_COMPLETED
-        )
-        for task in list(pending):
-            task.cancel()
-        result = list(done)[0].result()
-        return result
+        loop = loop or asyncio.get_event_loop()
+        with_unicast = loop.create_task(cls._discover_gateway(
+            lan_address, gateway_address, timeout, igd_args, loop, unicast=True
+        ))
+        without_unicast = loop.create_task(cls._discover_gateway(
+            lan_address, gateway_address, timeout, igd_args, loop, unicast=False
+        ))
+        await asyncio.wait([with_unicast, without_unicast], return_when=asyncio.tasks.FIRST_COMPLETED)
+        if with_unicast and not with_unicast.done():
+            with_unicast.cancel()
+            if without_unicast.done():
+                return without_unicast.result()
+        elif without_unicast and not without_unicast.done():
+            without_unicast.cancel()
+            if with_unicast.done() and not with_unicast.cancelled():
+                return with_unicast.result()
+        else:
+            with_unicast.exception()
+            without_unicast.exception()
+            return with_unicast.result()
 
     async def discover_commands(self, loop=None):
         response, xml_bytes, get_err = await scpd_get(self.path.decode(), self.base_ip.decode(), self.port, loop=loop)

--- a/aioupnp/upnp.py
+++ b/aioupnp/upnp.py
@@ -394,7 +394,7 @@ class UPnP:
         try:
             result = fut.result()
         except UPnPError as err:
-            print("aioupnp encountered an error:\n%s" % str(err))
+            print("aioupnp encountered an error: %s" % str(err))
             return
 
         if isinstance(result, (list, tuple, dict)):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,7 +85,7 @@ class TestCLI(TestBase):
 
     def test_m_search(self):
         actual_output = StringIO()
-        timeout_msg = "aioupnp encountered an error:\nM-SEARCH for 10.0.0.1:1900 timed out\n"
+        timeout_msg = "aioupnp encountered an error: M-SEARCH for 10.0.0.1:1900 timed out\n"
         with contextlib.redirect_stdout(actual_output):
             with mock_tcp_and_udp(self.loop, '10.0.0.1', tcp_replies=self.scpd_replies, udp_replies=self.udp_replies):
                 main(

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,3 +1,6 @@
+import asyncio
+
+from aioupnp.fault import UPnPError
 from tests import TestBase
 from tests.mocks import mock_tcp_and_udp
 from collections import OrderedDict
@@ -61,6 +64,16 @@ class TestDiscoverDLinkDIR890L(TestBase):
         'DeletePortMapping': 'urn:schemas-upnp-org:service:WANIPConnection:1',
         'GetExternalIPAddress': 'urn:schemas-upnp-org:service:WANIPConnection:1'
     }
+
+    async def test_discover_gateway(self):
+        with self.assertRaises(UPnPError) as e1:
+            with mock_tcp_and_udp(self.loop):
+                await Gateway.discover_gateway("10.0.0.2", "10.0.0.1", 2)
+        with self.assertRaises(UPnPError) as e2:
+            with mock_tcp_and_udp(self.loop):
+                await Gateway.discover_gateway("10.0.0.2", "10.0.0.1", 2, unicast=False)
+        self.assertEqual(str(e1.exception), "M-SEARCH for 10.0.0.1:1900 timed out")
+        self.assertEqual(str(e2.exception), "M-SEARCH for 10.0.0.1:1900 timed out")
 
     async def test_discover_commands(self):
         with mock_tcp_and_udp(self.loop, tcp_replies=self.replies):


### PR DESCRIPTION
This is done to prevent python spewing out `"Task exception not retrieved"` as `asyncio.wait()` doesn't consume tasks...
Also small fix, to pass `unicast` to `_discover_gateway` if set