### PR TITLE
use appropriate asserts in tests

### DIFF
--- a/tests/protocols/test_multicast.py
+++ b/tests/protocols/test_multicast.py
@@ -23,8 +23,8 @@ class TestMulticast(unittest.TestCase):
         protocol = MulticastProtocol('1.2.3.4', '1.2.3.4')
         transport = DatagramTransport()
         transport._extra = {'socket': mock_socket}
-        self.assertEqual(None, protocol.set_ttl(1))
+        self.assertIsNone(protocol.set_ttl(1))
         self.assertEqual(0, protocol.get_ttl())
         protocol.connection_made(transport)
-        self.assertEqual(None, protocol.set_ttl(1))
+        self.assertIsNone(protocol.set_ttl(1))
         self.assertEqual(1, protocol.get_ttl())

--- a/tests/protocols/test_scpd.py
+++ b/tests/protocols/test_scpd.py
@@ -108,7 +108,7 @@ class TestSCPDGet(AsyncioTestCase):
         replies = {self.get_request: self.response}
         with mock_tcp_and_udp(self.loop, tcp_replies=replies, sent_tcp_packets=sent):
             result, raw, err = await scpd_get(self.path, self.lan_address, self.port, self.loop)
-            self.assertEqual(None, err)
+            self.assertIsNone(err)
             self.assertDictEqual(self.expected_parsed, result)
 
     async def test_scpd_get_timeout(self):
@@ -116,7 +116,7 @@ class TestSCPDGet(AsyncioTestCase):
         replies = {}
         with mock_tcp_and_udp(self.loop, tcp_replies=replies, sent_tcp_packets=sent):
             result, raw, err = await scpd_get(self.path, self.lan_address, self.port, self.loop)
-            self.assertTrue(isinstance(err, UPnPError))
+            self.assertIsInstance(err, UPnPError)
             self.assertDictEqual({}, result)
             self.assertEqual(b'', raw)
 
@@ -127,7 +127,7 @@ class TestSCPDGet(AsyncioTestCase):
             result, raw, err = await scpd_get(self.path, self.lan_address, self.port, self.loop)
             self.assertDictEqual({}, result)
             self.assertEqual(self.bad_response, raw)
-            self.assertTrue(isinstance(err, UPnPError))
+            self.assertIsInstance(err, UPnPError)
             self.assertTrue(str(err).startswith('no element found'))
 
     async def test_scpd_get_overrun_content_length(self):
@@ -137,7 +137,7 @@ class TestSCPDGet(AsyncioTestCase):
             result, raw, err = await scpd_get(self.path, self.lan_address, self.port, self.loop)
             self.assertDictEqual({}, result)
             self.assertEqual(self.bad_response + b'\r\n', raw)
-            self.assertTrue(isinstance(err, UPnPError))
+            self.assertIsInstance(err, UPnPError)
             self.assertTrue(str(err).startswith('too many bytes written'))
 
 
@@ -186,7 +186,7 @@ class TestSCPDPost(AsyncioTestCase):
             result, raw, err = await scpd_post(
                 self.path, self.gateway_address, self.port, self.method, self.param_names, self.st, self.loop
             )
-            self.assertEqual(None, err)
+            self.assertIsNone(err)
             self.assertEqual(self.post_response, raw)
             self.assertDictEqual({'NewExternalIPAddress': '11.22.33.44'}, result)
 
@@ -197,7 +197,7 @@ class TestSCPDPost(AsyncioTestCase):
             result, raw, err = await scpd_post(
                 self.path, self.gateway_address, self.port, self.method, self.param_names, self.st, self.loop
             )
-            self.assertTrue(isinstance(err, UPnPError))
+            self.assertIsInstance(err, UPnPError)
             self.assertTrue(str(err).startswith('Timeout'))
             self.assertEqual(b'', raw)
             self.assertDictEqual({}, result)
@@ -209,7 +209,7 @@ class TestSCPDPost(AsyncioTestCase):
             result, raw, err = await scpd_post(
                 self.path, self.gateway_address, self.port, self.method, self.param_names, self.st, self.loop
             )
-            self.assertTrue(isinstance(err, UPnPError))
+            self.assertIsInstance(err, UPnPError)
             self.assertTrue(str(err).startswith('no element found'))
             self.assertEqual(self.bad_envelope_response, raw)
             self.assertDictEqual({}, result)
@@ -221,7 +221,7 @@ class TestSCPDPost(AsyncioTestCase):
             result, raw, err = await scpd_post(
                 self.path, self.gateway_address, self.port, self.method, self.param_names, self.st, self.loop
             )
-            self.assertTrue(isinstance(err, UPnPError))
+            self.assertIsInstance(err, UPnPError)
             self.assertTrue(str(err).startswith('too many bytes written'))
             self.assertEqual(self.post_response + b'\r\n', raw)
             self.assertDictEqual({}, result)

--- a/tests/serialization/test_soap.py
+++ b/tests/serialization/test_soap.py
@@ -102,7 +102,7 @@ class TestSOAPSerialization(unittest.TestCase):
             deserialize_soap_post_response(self.error_response, self.method, service_id=self.st.decode())
         except UPnPError as err:
             raised = True
-            self.assertTrue(str(err) == 'SpecifiedArrayIndexInvalid')
+            self.assertEqual(str(err), 'SpecifiedArrayIndexInvalid')
         self.assertTrue(raised)
 
     def test_raise_from_error_response_without_error_description(self):
@@ -112,5 +112,5 @@ class TestSOAPSerialization(unittest.TestCase):
             deserialize_soap_post_response(self.error_response_no_description, self.method, service_id=self.st.decode())
         except UPnPError as err:
             raised = True
-            self.assertTrue(str(err) == expected)
+            self.assertEqual(str(err), expected)
         self.assertTrue(raised)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -67,4 +67,4 @@ class TestParseInterfaces(AsyncioTestCase):
                 checked.append(True)
             else:
                 self.assertTrue(False)
-        self.assertTrue(len(checked) == 1)
+        self.assertEqual(len(checked), 1)

--- a/tests/test_upnp.py
+++ b/tests/test_upnp.py
@@ -141,7 +141,7 @@ class TestGetNextPortMapping(UPnPCommandTestCase):
             ext_port = await upnp.get_next_mapping(4567, "UDP", "aioupnp test mapping")
             self.assertEqual(4567, ext_port)
             result = await upnp.delete_port_mapping(ext_port, "UDP")
-            self.assertEqual(None, result)
+            self.assertIsNone(result)
 
 
 class TestGetSpecificPortMapping(UPnPCommandTestCase):


### PR DESCRIPTION
Especially, `foo == None` is dangerous one, and `is None` should be used: https://www.python.org/dev/peps/pep-0008/#programming-recommendations.