### PR TITLE
Support for Python 3.10: Remove loop parameter from asyncio primitives

### DIFF
--- a/aioupnp/__init__.py
+++ b/aioupnp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.18"
+__version__ = "0.0.19"
 __author__ = "Jack Robison"
 __maintainer__ = "Jack Robison"
 __license__ = "MIT"

--- a/aioupnp/gateway.py
+++ b/aioupnp/gateway.py
@@ -224,7 +224,7 @@ class Gateway:
         try:
             return await asyncio.wait_for(loop.create_task(
                 cls._discover_gateway(lan_address, gateway_address, timeout, loop)
-            ), timeout, loop=loop)
+            ), timeout)
         except asyncio.TimeoutError:
             raise UPnPError(f"M-SEARCH for {gateway_address}:1900 timed out")
 

--- a/aioupnp/protocols/scpd.py
+++ b/aioupnp/protocols/scpd.py
@@ -141,7 +141,7 @@ async def scpd_get(control_url: str, address: str, port: int,
     assert isinstance(protocol, SCPDHTTPClientProtocol)
 
     error = None
-    wait_task: typing.Awaitable[typing.Tuple[bytes, bytes, int, bytes]] = asyncio.wait_for(protocol.finished, 1.0, loop=loop)
+    wait_task: typing.Awaitable[typing.Tuple[bytes, bytes, int, bytes]] = asyncio.wait_for(protocol.finished, 1.0)
     body = b''
     raw_response = b''
     try:
@@ -182,7 +182,7 @@ async def scpd_post(control_url: str, address: str, port: int, method: str, para
     assert isinstance(protocol, SCPDHTTPClientProtocol)
 
     try:
-        wait_task: typing.Awaitable[typing.Tuple[bytes, bytes, int, bytes]] = asyncio.wait_for(finished, 1.0, loop=loop)
+        wait_task: typing.Awaitable[typing.Tuple[bytes, bytes, int, bytes]] = asyncio.wait_for(finished, 1.0)
         raw_response, body, response_code, response_msg = await wait_task
     except asyncio.TimeoutError:
         return {}, b'', UPnPError("Timeout")

--- a/aioupnp/protocols/ssdp.py
+++ b/aioupnp/protocols/ssdp.py
@@ -31,8 +31,8 @@ class SSDPProtocol(MulticastProtocol):
         self.transport: Optional[DatagramTransport] = None
         self._pending_searches: List[PendingSearch] = []
         self.notifications: List[SSDPDatagram] = []
-        self.connected = asyncio.Event(loop=self.loop)
-        self.devices: 'asyncio.Queue[SSDPDatagram]' = asyncio.Queue(loop=self.loop)
+        self.connected = asyncio.Event()
+        self.devices: 'asyncio.Queue[SSDPDatagram]' = asyncio.Queue()
 
     def connection_made(self, transport: asyncio.DatagramTransport) -> None:  # type: ignore
         super().connection_made(transport)
@@ -98,7 +98,7 @@ class SSDPProtocol(MulticastProtocol):
     async def m_search(self, address: str, timeout: float,
                        datagrams: List[Dict[str, typing.Union[str, int]]]) -> SSDPDatagram:
         fut = self.send_m_searches(address, datagrams)
-        return await asyncio.wait_for(fut, timeout, loop=self.loop)
+        return await asyncio.wait_for(fut, timeout)
 
     def datagram_received(self, data: bytes, addr: Tuple[str, int]) -> None:  # type: ignore
         if addr[0] == self.bind_address:

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,10 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: System :: Networking",
         "Topic :: Communications :: File Sharing"
     ],


### PR DESCRIPTION
`loop=...` argument in asyncio primitives has been deprecated for a while now -- since Python 3.8

This therefore drops support for 3.7.

Fixes #29